### PR TITLE
Replace the .sub_title class by the <small> tag

### DIFF
--- a/chrome-bootstrap.less
+++ b/chrome-bootstrap.less
@@ -76,7 +76,6 @@ h4 {
     -webkit-margin-end: 15px;
     width: 155px;
     z-index: 3;
-    background-color: #FFF;
   }
   .view, .content {
     width: 738px;


### PR DESCRIPTION
Amazing project but the `.sub_title` class is painful to use, the `<small>` tag is a better way to manage subtitles, like Twitter Bootstrap.
