### PR TITLE
Added bower.json so this can be on Bower

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,20 @@
+{
+  "name": "chrome-bootstrap",
+  "version": "1.2.1",
+  "description": "Chrome UI bootstrap",
+  "main": "chrome-bootstrap.css",
+  "license": "MIT",
+  "ignore": [
+    "**/.*",
+    "node_modules"
+  ],
+  "keywords": [
+    "google",
+    "chrome",
+    "extension",
+    "ui",
+    "bootstrap",
+    "settings",
+    "less"
+  ]
+}


### PR DESCRIPTION
Being able to install this with Bower would actually be quite useful in my opinion.
Running `bower register chrome-bootstrap git://github.com/roykolak/chrome-bootstrap.git` after the pull would close #5
