### PR TITLE
Added password input type to styles

### DIFF
--- a/chrome-bootstrap.css
+++ b/chrome-bootstrap.css
@@ -532,6 +532,7 @@
 }
 .chrome-bootstrap input[type='text'],
 .chrome-bootstrap input[type='number'],
+.chrome-bootstrap input[type='password'],
 .chrome-bootstrap input[type='search'] {
   border: 1px solid #BFBFBF;
   border-radius: 2px;
@@ -583,6 +584,7 @@
 }
 .chrome-bootstrap input[type='search']:disabled,
 .chrome-bootstrap input[type='number']:disabled,
+.chrome-bootstrap input[type='password']:disabled,
 .chrome-bootstrap input[type='text']:disabled {
   color: #999;
 }

--- a/chrome-bootstrap.less
+++ b/chrome-bootstrap.less
@@ -562,6 +562,7 @@
   }
   input[type='text'],
   input[type='number'],
+  input[type='password'],
   input[type='search'] {
     border: 1px solid #BFBFBF;
     border-radius: 2px;
@@ -622,6 +623,7 @@
   }
   input[type='search'],
   input[type='number'],
+  input[type='password'],
   input[type='text'] {
     &:disabled {
       color: #999;


### PR DESCRIPTION
I noticed text input styles were not applied to `type="password"` fields. This fixes this issue.

Regards.